### PR TITLE
Add PRQL: Generate SQL File command and editor context menu options

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,12 @@
         "title": "Open SQL Preview",
         "category": "PRQL",
         "icon": "$(open-preview)"
+      },
+      {
+        "command": "prql.generateSqlFile",
+        "title": "Generate SQL File",
+        "category": "PRQL",
+        "icon": "$(database)"
       }
     ],
     "menus": {
@@ -54,11 +60,21 @@
           "command": "prql.openSqlPreview",
           "when": "resourceFilename =~ /\\.prql$/",
           "group": "navigation"
+        },
+        {
+          "command": "prql.generateSqlFile",
+          "when": "resourceFilename =~ /\\.prql$/",
+          "group": "navigation"
         }
       ],
       "editor/title/context": [
         {
           "command": "prql.openSqlPreview",
+          "when": "resourceFilename =~ /\\.prql$/",
+          "group": "navigation"
+        },
+        {
+          "command": "prql.generateSqlFile",
           "when": "resourceFilename =~ /\\.prql$/",
           "group": "navigation"
         }

--- a/package.json
+++ b/package.json
@@ -52,14 +52,14 @@
       "editor/title": [
         {
           "command": "prql.openSqlPreview",
-          "when": "resourceFilename =~ /.*(.prql)/",
+          "when": "resourceFilename =~ /\\.prql$/",
           "group": "navigation"
         }
       ],
       "editor/title/context": [
         {
           "command": "prql.openSqlPreview",
-          "when": "resourceFilename =~ /.*\\.(prql)/",
+          "when": "resourceFilename =~ /\\.prql$/",
           "group": "navigation"
         }
       ]

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,9 +1,17 @@
 import {
-  ExtensionContext,
   commands,
+  window,
+  workspace,
+  Disposable,
+  ExtensionContext,
+  Uri
 } from 'vscode';
 
+import * as path from 'path';
 import * as constants from './constants';
+
+import { compile } from './compiler';
+import { TextEncoder } from 'util';
 
 /**
  * Registers PRQL extension commands.
@@ -11,9 +19,65 @@ import * as constants from './constants';
  * @param context Extension context.
  */
 export function registerCommands(context: ExtensionContext) {
-  context.subscriptions.push(
-    commands.registerCommand(constants.GenerateSqlFile, () => {
-      // TODO: add Generate Sql File command implementation
-    })
-  );
+  registerCommand(context, constants.GenerateSqlFile, generateSqlFile);
+}
+
+/**
+ * Registers vscode extension command.
+ *
+ * @param context Extension context.
+ * @param commandId Command identifier.
+ * @param callback Command handler.
+ * @param thisArg The `this` context used when invoking command handler.
+ */
+function registerCommand(context: ExtensionContext, commandId: string,
+  callback: (...args: any[]) => any, thisArg?: any): void {
+
+  const command: Disposable = commands.registerCommand(commandId, async (...args) => {
+    try {
+      await callback(...args);
+    } catch (e: unknown) {
+      window.showErrorMessage(String(e));
+      console.error(e);
+    }
+  }, thisArg);
+
+  context.subscriptions.push(command);
+}
+
+/**
+ * Compiles PRQL text from the active text editor,
+ * and creates or updates the corresponding SQL file
+ * with PRQL compiler output.
+ *
+ * Opens generated SQL file in text editor for code formatting,
+ * or running generated SQL statements with available
+ * vscode database extensions and sql tools.
+ */
+async function generateSqlFile() {
+  const editor = window.activeTextEditor;
+
+  if (editor && editor.document.languageId === 'prql') {
+    // compile PRQL
+    const prql = editor.document.getText();
+    const result = compile(prql);
+
+    if (Array.isArray(result)) {
+      window.showErrorMessage(`PRQL Compile \
+        ${result[0].display ?? result[0].reason}`);
+    }
+    else {
+      // create sql file
+      const prqlDocumentUri: Uri = editor.document.uri;
+      const prqlFilePath = path.parse(prqlDocumentUri.fsPath);
+      const sqlFilePath = path.join(prqlFilePath.dir, `${prqlFilePath.name}.sql`);
+      const sqlFileUri: Uri = Uri.file(sqlFilePath);
+      const textEncoder: TextEncoder = new TextEncoder()
+      const sqlContent: Uint8Array = textEncoder.encode(result);
+      await workspace.fs.writeFile(sqlFileUri, sqlContent);
+
+      // show generated sql file
+      await window.showTextDocument(sqlFileUri);
+    }
+  }
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,0 +1,19 @@
+import {
+  ExtensionContext,
+  commands,
+} from 'vscode';
+
+import * as constants from './constants';
+
+/**
+ * Registers PRQL extension commands.
+ *
+ * @param context Extension context.
+ */
+export function registerCommands(context: ExtensionContext) {
+  context.subscriptions.push(
+    commands.registerCommand(constants.GenerateSqlFile, () => {
+      // TODO: add Generate Sql File command implementation
+    })
+  );
+}

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1,4 +1,4 @@
-import * as prqlJs from "prql-js";
+import * as prqlJs from 'prql-js';
 
 export function compile(prqlString: string): string | ErrorMessage[] {
   try {
@@ -36,7 +36,5 @@ export interface ErrorMessage {
 /// - column number within that line (0-based),
 export interface SourceLocation {
   start: [number, number];
-
   end: [number, number];
 }
-

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,19 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+/**
+ * PRQL extension constants.
+ */
+
+// Extension constants
+export const PublisherId = 'PRQL-lang';
+export const ExtensionName = 'prql-vscode';
+export const ExtensionId = 'prql';
+export const ExtensionDisplayName = 'PRQL';
+
+// PRQL webview constants
+export const SqlPreviewPanel = `${ExtensionId}.sqlPreviewPanel`;
+export const SqlPreviewTitle = 'SQL Preview';
+
+// PRQL extension command constants
+export const OpenSqlPreview = `${ExtensionId}.openSqlPreview`;
+export const GenerateSqlFile = `${ExtensionId}.generateSqlFile`;

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,18 +1,30 @@
-import * as vscode from "vscode";
-import { isPrqlDocument } from "./utils";
-import { SourceLocation, compile } from "./compiler";
+import {
+  Diagnostic,
+  DiagnosticCollection,
+  DiagnosticSeverity,
+  ExtensionContext,
+  Position,
+  Range,
+  TextDocument,
+  languages,
+  window,
+  workspace
+} from 'vscode';
 
-function getRange(location: SourceLocation | null): vscode.Range {
+import { isPrqlDocument } from './utils';
+import { SourceLocation, compile } from './compiler';
+
+function getRange(location: SourceLocation | null): Range {
   if (location) {
-    return new vscode.Range(location.start[0], location.start[1], location.end[0],
+    return new Range(location.start[0], location.start[1], location.end[0],
       location.end[1]);
   }
 
-  return new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0));
+  return new Range(new Position(0, 0), new Position(0, 0));
 }
 
-function updateLineDiagnostics(diagnosticCollection: vscode.DiagnosticCollection) {
-  const editor = vscode.window.activeTextEditor;
+function updateLineDiagnostics(diagnosticCollection: DiagnosticCollection) {
+  const editor = window.activeTextEditor;
 
   if (editor && isPrqlDocument(editor)) {
     const text = editor.document.getText();
@@ -22,24 +34,24 @@ function updateLineDiagnostics(diagnosticCollection: vscode.DiagnosticCollection
       diagnosticCollection.set(editor.document.uri, []);
     } else {
       const range = getRange(result[0].location);
-      const diagnostic = new vscode.Diagnostic(range, result[0].reason ?? "Syntax Error",
-        vscode.DiagnosticSeverity.Error);
+      const diagnostic = new Diagnostic(range, result[0].reason ?? 'Syntax Error',
+        DiagnosticSeverity.Error);
       diagnosticCollection.set(editor.document.uri, [diagnostic]);
     }
   }
 }
 
-export function activateDiagnostics(context: vscode.ExtensionContext) {
-  const diagnosticCollection = vscode.languages.createDiagnosticCollection("prql");
+export function activateDiagnostics(context: ExtensionContext) {
+  const diagnosticCollection = languages.createDiagnosticCollection('prql');
   context.subscriptions.push(diagnosticCollection);
 
-  vscode.workspace.onDidCloseTextDocument((document: vscode.TextDocument) =>
+  workspace.onDidCloseTextDocument((document: TextDocument) =>
     diagnosticCollection.set(document.uri, []));
 
   [
-    vscode.workspace.onDidOpenTextDocument,
-    vscode.workspace.onDidChangeTextDocument,
-    vscode.window.onDidChangeActiveTextEditor
+    workspace.onDidOpenTextDocument,
+    workspace.onDidChangeTextDocument,
+    window.onDidChangeActiveTextEditor
   ].forEach(event => {
     context.subscriptions.push(event(() => updateLineDiagnostics(diagnosticCollection)));
   });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,8 +1,15 @@
-import * as vscode from "vscode";
-import { activateSqlOutputPanel } from "./sql_output";
-import { activateDiagnostics } from "./diagnostics";
+import { ExtensionContext } from 'vscode';
+import { activateSqlPreviewPanel } from './sql_output';
+import { activateDiagnostics } from './diagnostics';
 
-export function activate(context: vscode.ExtensionContext) {
+/**
+ * Activates PRQL extension,
+ * enables PRQL text document diagnostics,
+ * and registers Open SQL Preview command.
+ *
+ * @param context Extension context.
+ */
+export function activate(context: ExtensionContext) {
   activateDiagnostics(context);
-  activateSqlOutputPanel(context);
+  activateSqlPreviewPanel(context);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,15 +1,18 @@
 import { ExtensionContext } from 'vscode';
 import { activateSqlPreviewPanel } from './sql_output';
 import { activateDiagnostics } from './diagnostics';
+import { registerCommands } from './commands';
 
 /**
  * Activates PRQL extension,
  * enables PRQL text document diagnostics,
- * and registers Open SQL Preview command.
+ * registers Open SQL Preview and other
+ * PRQL extension commands.
  *
  * @param context Extension context.
  */
 export function activate(context: ExtensionContext) {
   activateDiagnostics(context);
   activateSqlPreviewPanel(context);
+  registerCommands(context);
 }

--- a/src/sql_output/index.ts
+++ b/src/sql_output/index.ts
@@ -23,6 +23,7 @@ import {
 
 import { isPrqlDocument } from '../utils';
 import { compile } from '../compiler';
+import * as constants from '../constants';
 
 function getCompiledTemplate(context: ExtensionContext, webview: Webview): string {
   const template = readFileSync(getResourceUri(context, 'sql_output.html').fsPath, 'utf-8');
@@ -76,7 +77,7 @@ async function compilePrql(text: string, lastOkHtml: string | undefined):
   const highlighted = highlighter.codeToHtml(result, { lang: 'sql' });
 
   return {
-    status: "ok",
+    status: 'ok',
     html: highlighted
   };
 }
@@ -103,7 +104,7 @@ function sendThemeChanged(panel: WebviewPanel) {
 
 function createWebviewPanel(context: ExtensionContext, onDidDispose: () => any): WebviewPanel {
 const panel = window.createWebviewPanel(
-    'prql.sqlPreviewPanel', 'SQL Preview',
+    constants.SqlPreviewPanel, constants.SqlPreviewTitle,
     {
       viewColumn: ViewColumn.Beside,
       preserveFocus: true
@@ -157,7 +158,7 @@ export function activateSqlPreviewPanel(context: ExtensionContext) {
   let panel: WebviewPanel | undefined = undefined;
   let panelViewColumn: ViewColumn | undefined = undefined;
 
-  const command = commands.registerCommand('prql.openSqlPreview', () => {
+  const command = commands.registerCommand(constants.OpenSqlPreview, () => {
     if (panel) {
       panel.reveal(panelViewColumn, true);
     } else {

--- a/src/sql_output/utils.ts
+++ b/src/sql_output/utils.ts
@@ -1,7 +1,10 @@
-import * as vscode from "vscode";
+import {
+  ExtensionContext,
+  Uri
+} from 'vscode';
 
 export interface CompilationResult {
-  status: "ok" | "error";
+  status: 'ok' | 'error';
   html?: string;
   error?: {
     message: string;
@@ -9,15 +12,15 @@ export interface CompilationResult {
   last_html?: string | undefined;
 }
 
-export function getResourceUri(context: vscode.ExtensionContext, filename: string) {
-  return vscode.Uri.joinPath(context.extensionUri, "resources", filename);
+export function getResourceUri(context: ExtensionContext, filename: string) {
+  return Uri.joinPath(context.extensionUri, 'resources', filename);
 }
 
 export function normalizeThemeName(currentTheme: string): string {
   return currentTheme
     .toLowerCase()
-    .replace("theme", "")
-    .replace(/\s+/g, "-");
+    .replace('theme', '')
+    .replace(/\s+/g, '-');
 }
 
 export function debounce(fn: () => any, timeout: number) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
-import * as vscode from "vscode";
+import { TextEditor } from 'vscode';
 
-export function isPrqlDocument(editor: vscode.TextEditor): boolean {
-  return editor.document.languageId === "prql";
+export function isPrqlDocument(editor: TextEditor): boolean {
+  return editor.document.languageId === 'prql';
 }


### PR DESCRIPTION
Implements basic Prql to Sql file generation workflow as described in #42.

I added database icon menu option to the editor title bar context menu as both prql and sql files use similar icons, and there are no other database related actions for open prql documents implemented by Prql extension currently.

Preview of integrated workflow with this functionality using [DuckDB Sql Tools](https://marketplace.visualstudio.com/items?itemName=RandomFractalsInc.duckdb-sql-tools) and sample [`chinook.duckdb`](https://github.com/RandomFractals/duckdb-sql-tools/tree/main/data/chinook/duckdb) and [daily-invoice-totals.prql](https://github.com/RandomFractals/duckdb-sql-tools/blob/main/data/chinook/duckdb/daily-invoice-totals.prql) from our extension docs repo:

![duckdb-prql-sql-run](https://user-images.githubusercontent.com/656833/217057247-0a4d0a18-f189-4543-9bd4-28da58b39ddc.gif)
