### PR TITLE
Copy SQL to Clipboard UX

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "activationEvents": [
     "onLanguage:prql",
     "onCommand:prql.openSqlPreview",
-    "onCommand:prql.generateSqlFile"
+    "onCommand:prql.generateSqlFile",
+    "onCommand:prql.copySqlToClipboard"
   ],
   "contributes": {
     "languages": [
@@ -57,6 +58,12 @@
         "title": "Generate SQL File",
         "category": "PRQL",
         "icon": "$(database)"
+      },
+      {
+        "command": "prql.copySqlToClipboard",
+        "title": "Copy SQL to Clipboard",
+        "category": "PRQL",
+        "icon": "$(copy)"
       }
     ],
     "menus": {
@@ -69,6 +76,11 @@
         {
           "command": "prql.generateSqlFile",
           "when": "resourceFilename =~ /\\.prql$/",
+          "group": "navigation"
+        },
+        {
+          "command": "prql.copySqlToClipboard",
+          "when": "prql.sql",
           "group": "navigation"
         }
       ],

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
         },
         {
           "command": "prql.copySqlToClipboard",
-          "when": "prql.sqlPreivewActive",
+          "when": "prql.sqlPreviewActive",
           "group": "navigation"
         }
       ],

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
         },
         {
           "command": "prql.copySqlToClipboard",
-          "when": "prql.sql",
+          "when": "prql.sqlPreivewActive",
           "group": "navigation"
         }
       ],

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,5 +1,6 @@
 import {
   commands,
+  env,
   window,
   workspace,
   Disposable,
@@ -20,6 +21,15 @@ import { TextEncoder } from "util";
  */
 export function registerCommands(context: ExtensionContext) {
   registerCommand(context, constants.GenerateSqlFile, generateSqlFile);
+
+  registerCommand(context, constants.CopySqlToClipboard, () => {
+    const sql: string | undefined = context.workspaceState.get('prql.sql');
+    if (sql) {
+      // write the last generated sql code to vscode clipboard
+      env.clipboard.writeText(sql);
+      window.showInformationMessage('PRQL: SQL copied to Clipboard.');
+    }
+  });
 }
 
 /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,3 +18,6 @@ export const SqlPreviewTitle = "SQL Preview";
 export const OpenSqlPreview = `${ExtensionId}.openSqlPreview`;
 export const GenerateSqlFile = `${ExtensionId}.generateSqlFile`;
 export const CopySqlToClipboard = `${ExtensionId}.copySqlToClipboard`;
+
+// PRQL context keys
+export const SqlPreviewActive = `${ExtensionId}.sqlPreivewActive`;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,4 +20,4 @@ export const GenerateSqlFile = `${ExtensionId}.generateSqlFile`;
 export const CopySqlToClipboard = `${ExtensionId}.copySqlToClipboard`;
 
 // PRQL context keys
-export const SqlPreviewActive = `${ExtensionId}.sqlPreivewActive`;
+export const SqlPreviewActive = `${ExtensionId}.sqlPreviewActive`;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,3 +17,4 @@ export const SqlPreviewTitle = "SQL Preview";
 // PRQL extension command constants
 export const OpenSqlPreview = `${ExtensionId}.openSqlPreview`;
 export const GenerateSqlFile = `${ExtensionId}.generateSqlFile`;
+export const CopySqlToClipboard = `${ExtensionId}.copySqlToClipboard`;

--- a/src/sql_output/utils.ts
+++ b/src/sql_output/utils.ts
@@ -3,6 +3,7 @@ import { ExtensionContext, Uri } from "vscode";
 export interface CompilationResult {
   status: "ok" | "error";
   html?: string;
+  sql?: string;
   error?: {
     message: string;
   };


### PR DESCRIPTION
Adds Copy SQL to Clipboard from an active SQL Preview (#55).

This PR adds `Copy` icon button to the Prql editor and Sql Preview, and copies generated SQL output from the Preview panel to vscode clipboard.

Brief demo:

![prql-sql-copy-to-clipboard](https://user-images.githubusercontent.com/656833/217396269-67e4e418-436a-4873-9644-f95e7c299a2b.gif)
