### PR TITLE
Update and use new eslint rules from .eslintrc.json

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,6 +30,11 @@
         "avoidEscape": true,
         "allowTemplateLiterals": true
       }
-    ]
+    ],
+    "@typescript-eslint/naming-convention": "warn",
+    "@typescript-eslint/semi": "warn",
+    "curly": "warn",
+    "eqeqeq": "warn",
+    "no-throw-literal": "warn"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,12 +1,35 @@
 {
   "root": true,
-  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
   "parser": "@typescript-eslint/parser",
-  "parserOptions": { "project": ["./tsconfig.json"] },
-  "plugins": ["@typescript-eslint"],
-  "ignorePatterns": ["out", "resources"],
+  "parserOptions": {
+    "project": [
+      "./tsconfig.json"
+    ]
+  },
+  "plugins": [
+    "@typescript-eslint"
+  ],
+  "ignorePatterns": [
+    "out",
+    "resources"
+  ],
   "rules": {
     "@typescript-eslint/no-explicit-any": "off",
-    "eol-last": ["error", "always"]
+    "eol-last": [
+      "error",
+      "always"
+    ],
+    "@typescript-eslint/quotes": [
+      "error",
+      "single",
+      {
+        "avoidEscape": true,
+        "allowTemplateLiterals": true
+      }
+    ]
   }
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,12 +12,12 @@ repos:
       - id: typos
         # https://github.com/crate-ci/typos/issues/347
         pass_filenames: false
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.4
-    hooks:
-      - id: prettier
-        additional_dependencies:
-          - prettier
+  # - repo: https://github.com/pre-commit/mirrors-prettier
+  #  rev: v3.0.0-alpha.4
+  #  hooks:
+  #    - id: prettier
+  #      additional_dependencies:
+  #        - prettier
 ci:
   # Currently network access isn't supported in the CI product.
   autoupdate_commit_msg: "chore: pre-commit autoupdate"

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -6,13 +6,13 @@ import {
   Disposable,
   ExtensionContext,
   Uri,
-} from "vscode";
+} from 'vscode';
 
-import * as path from "path";
-import * as constants from "./constants";
+import * as path from 'path';
+import * as constants from './constants';
 
-import { compile } from "./compiler";
-import { TextEncoder } from "util";
+import { compile } from './compiler';
+import { TextEncoder } from 'util';
 
 /**
  * Registers PRQL extension commands.
@@ -23,11 +23,11 @@ export function registerCommands(context: ExtensionContext) {
   registerCommand(context, constants.GenerateSqlFile, generateSqlFile);
 
   registerCommand(context, constants.CopySqlToClipboard, () => {
-    const sql: string | undefined = context.workspaceState.get("prql.sql");
+    const sql: string | undefined = context.workspaceState.get('prql.sql');
     if (sql) {
       // write the last generated sql code to vscode clipboard
       env.clipboard.writeText(sql);
-      window.showInformationMessage("PRQL: SQL copied to Clipboard.");
+      window.showInformationMessage('PRQL: SQL copied to Clipboard.');
     }
   });
 }
@@ -74,7 +74,7 @@ function registerCommand(
 async function generateSqlFile() {
   const editor = window.activeTextEditor;
 
-  if (editor && editor.document.languageId === "prql") {
+  if (editor && editor.document.languageId === 'prql') {
     // compile PRQL
     const prql = editor.document.getText();
     const result = compile(prql);

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1,4 +1,4 @@
-import * as prqlJs from "prql-js";
+import * as prqlJs from 'prql-js';
 
 export function compile(prqlString: string): string | ErrorMessage[] {
   try {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,14 +5,14 @@
  */
 
 // Extension constants
-export const PublisherId = "PRQL-lang";
-export const ExtensionName = "prql-vscode";
-export const ExtensionId = "prql";
-export const ExtensionDisplayName = "PRQL";
+export const PublisherId = 'PRQL-lang';
+export const ExtensionName = 'prql-vscode';
+export const ExtensionId = 'prql';
+export const ExtensionDisplayName = 'PRQL';
 
 // PRQL webview constants
 export const SqlPreviewPanel = `${ExtensionId}.sqlPreviewPanel`;
-export const SqlPreviewTitle = "SQL Preview";
+export const SqlPreviewTitle = 'SQL Preview';
 
 // PRQL extension command constants
 export const OpenSqlPreview = `${ExtensionId}.openSqlPreview`;

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -9,10 +9,10 @@ import {
   languages,
   window,
   workspace,
-} from "vscode";
+} from 'vscode';
 
-import { isPrqlDocument } from "./utils";
-import { SourceLocation, compile } from "./compiler";
+import { isPrqlDocument } from './utils';
+import { SourceLocation, compile } from './compiler';
 
 function getRange(location: SourceLocation | null): Range {
   if (location) {
@@ -40,7 +40,7 @@ function updateLineDiagnostics(diagnosticCollection: DiagnosticCollection) {
       const range = getRange(result[0].location);
       const diagnostic = new Diagnostic(
         range,
-        result[0].reason ?? "Syntax Error",
+        result[0].reason ?? 'Syntax Error',
         DiagnosticSeverity.Error
       );
       diagnosticCollection.set(editor.document.uri, [diagnostic]);
@@ -49,7 +49,7 @@ function updateLineDiagnostics(diagnosticCollection: DiagnosticCollection) {
 }
 
 export function activateDiagnostics(context: ExtensionContext) {
-  const diagnosticCollection = languages.createDiagnosticCollection("prql");
+  const diagnosticCollection = languages.createDiagnosticCollection('prql');
   context.subscriptions.push(diagnosticCollection);
 
   workspace.onDidCloseTextDocument((document: TextDocument) =>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
-import { ExtensionContext } from "vscode";
-import { activateSqlPreviewPanel } from "./sql_output";
-import { activateDiagnostics } from "./diagnostics";
-import { registerCommands } from "./commands";
+import { ExtensionContext } from 'vscode';
+import { activateSqlPreviewPanel } from './sql_output';
+import { activateDiagnostics } from './diagnostics';
+import { registerCommands } from './commands';
 
 /**
  * Activates PRQL extension,

--- a/src/sql_output/index.ts
+++ b/src/sql_output/index.ts
@@ -81,7 +81,7 @@ async function compilePrql(
       error: {
         message: result[0].display ?? result[0].reason,
       },
-      last_html: lastOkHtml,
+      lastHtml: lastOkHtml,
     };
   }
 

--- a/src/sql_output/index.ts
+++ b/src/sql_output/index.ts
@@ -9,43 +9,43 @@ import {
   commands,
   window,
   workspace,
-} from "vscode";
+} from 'vscode';
 
-import * as shiki from "shiki";
-import { readFileSync } from "node:fs";
+import * as shiki from 'shiki';
+import { readFileSync } from 'node:fs';
 
 import {
   CompilationResult,
   debounce,
   getResourceUri,
   normalizeThemeName,
-} from "./utils";
+} from './utils';
 
-import { isPrqlDocument } from "../utils";
-import { compile } from "../compiler";
-import * as constants from "../constants";
+import { isPrqlDocument } from '../utils';
+import { compile } from '../compiler';
+import * as constants from '../constants';
 
 function getCompiledTemplate(
   context: ExtensionContext,
   webview: Webview
 ): string {
   const template = readFileSync(
-    getResourceUri(context, "sql_output.html").fsPath,
-    "utf-8"
+    getResourceUri(context, 'sql_output.html').fsPath,
+    'utf-8'
   );
-  const templateJS = getResourceUri(context, "sql_output.js");
-  const templateCss = getResourceUri(context, "sql_output.css");
+  const templateJS = getResourceUri(context, 'sql_output.js');
+  const templateCss = getResourceUri(context, 'sql_output.css');
 
   return (template as string)
     .replace(/##CSP_SOURCE##/g, webview.cspSource)
-    .replace("##JS_URI##", webview.asWebviewUri(templateJS).toString())
-    .replace("##CSS_URI##", webview.asWebviewUri(templateCss).toString());
+    .replace('##JS_URI##', webview.asWebviewUri(templateJS).toString())
+    .replace('##CSS_URI##', webview.asWebviewUri(templateCss).toString());
 }
 
 function getThemeName(): string {
   const currentThemeName = workspace
-    .getConfiguration("workbench")
-    .get<string>("colorTheme", "dark-plus");
+    .getConfiguration('workbench')
+    .get<string>('colorTheme', 'dark-plus');
 
   for (const themeName of [
     currentThemeName,
@@ -56,7 +56,7 @@ function getThemeName(): string {
     }
   }
 
-  return "css-variables";
+  return 'css-variables';
 }
 
 let highlighter: shiki.Highlighter | undefined;
@@ -77,7 +77,7 @@ async function compilePrql(
 
   if (Array.isArray(result)) {
     return {
-      status: "error",
+      status: 'error',
       error: {
         message: result[0].display ?? result[0].reason,
       },
@@ -86,18 +86,18 @@ async function compilePrql(
   }
 
   const highlighter = await getHighlighter();
-  const highlighted = highlighter.codeToHtml(result, { lang: "sql" });
+  const highlighted = highlighter.codeToHtml(result, { lang: 'sql' });
 
   return {
-    status: "ok",
+    status: 'ok',
     html: highlighted,
     sql: result,
   };
 }
 
 function clearSqlContext(context: ExtensionContext) {
-  commands.executeCommand("setContext", constants.SqlPreviewActive, false);
-  context.workspaceState.update("prql.sql", undefined);
+  commands.executeCommand('setContext', constants.SqlPreviewActive, false);
+  context.workspaceState.update('prql.sql', undefined);
 }
 
 let lastOkHtml: string | undefined;
@@ -108,14 +108,14 @@ function sendText(context: ExtensionContext, panel: WebviewPanel) {
   if (panel.visible && editor && isPrqlDocument(editor)) {
     const text = editor.document.getText();
     compilePrql(text, lastOkHtml).then((result) => {
-      if (result.status === "ok") {
+      if (result.status === 'ok') {
         lastOkHtml = result.html;
       }
       panel.webview.postMessage(result);
 
       // set sql preview flag and update sql output
-      commands.executeCommand("setContext", constants.SqlPreviewActive, true);
-      context.workspaceState.update("prql.sql", result.sql);
+      commands.executeCommand('setContext', constants.SqlPreviewActive, true);
+      context.workspaceState.update('prql.sql', result.sql);
     });
   }
 
@@ -125,7 +125,7 @@ function sendText(context: ExtensionContext, panel: WebviewPanel) {
 }
 
 function sendThemeChanged(panel: WebviewPanel) {
-  panel.webview.postMessage({ status: "theme-changed" });
+  panel.webview.postMessage({ status: 'theme-changed' });
 }
 
 function createWebviewPanel(
@@ -142,11 +142,11 @@ function createWebviewPanel(
     {
       enableFindWidget: false,
       enableScripts: true,
-      localResourceRoots: [Uri.joinPath(context.extensionUri, "resources")],
+      localResourceRoots: [Uri.joinPath(context.extensionUri, 'resources')],
     }
   );
   panel.webview.html = getCompiledTemplate(context, panel.webview);
-  panel.iconPath = getResourceUri(context, "favicon.ico");
+  panel.iconPath = getResourceUri(context, 'favicon.ico');
 
   const disposables: Disposable[] = [];
 

--- a/src/sql_output/utils.ts
+++ b/src/sql_output/utils.ts
@@ -7,7 +7,7 @@ export interface CompilationResult {
   error?: {
     message: string;
   };
-  last_html?: string | undefined;
+  lastHtml?: string | undefined;
 }
 
 export function getResourceUri(context: ExtensionContext, filename: string) {

--- a/src/sql_output/utils.ts
+++ b/src/sql_output/utils.ts
@@ -1,7 +1,7 @@
-import { ExtensionContext, Uri } from "vscode";
+import { ExtensionContext, Uri } from 'vscode';
 
 export interface CompilationResult {
-  status: "ok" | "error";
+  status: 'ok' | 'error';
   html?: string;
   sql?: string;
   error?: {
@@ -11,11 +11,11 @@ export interface CompilationResult {
 }
 
 export function getResourceUri(context: ExtensionContext, filename: string) {
-  return Uri.joinPath(context.extensionUri, "resources", filename);
+  return Uri.joinPath(context.extensionUri, 'resources', filename);
 }
 
 export function normalizeThemeName(currentTheme: string): string {
-  return currentTheme.toLowerCase().replace("theme", "").replace(/\s+/g, "-");
+  return currentTheme.toLowerCase().replace('theme', '').replace(/\s+/g, '-');
 }
 
 export function debounce(fn: () => any, timeout: number) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
-import { TextEditor } from "vscode";
+import { TextEditor } from 'vscode';
 
 export function isPrqlDocument(editor: TextEditor): boolean {
-  return editor.document.languageId === "prql";
+  return editor.document.languageId === 'prql';
 }


### PR DESCRIPTION
- Use single quote strings (#61)
- camelCase naming conventions
- some other warn rules (see changes in `.eslintrc.json`)

And remove pre-commit bot prettier hooks and checks.

We'll use new eslint rules instead to make our commits more bot comments and code changes free.

Our `compile` script in `package.json` already runs `eslint` and should be checking those rules for a passing build before commit: ```eslint --max-warnings 0 . && tsc -p ./``` 