### PR TITLE
Add prql.target ext. setting and use it in prql compile call

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,30 @@
           "group": "navigation"
         }
       ]
+    },
+    "configuration": {
+      "title": "PRQL",
+      "type": "object",
+      "properties": {
+        "prql.target": {
+          "type": "string",
+          "enum": [
+            "Ansi",
+            "BigQuery",
+            "ClickHouse",
+            "DuckDb",
+            "Generic",
+            "Hive",
+            "MsSql",
+            "MySql",
+            "PostgreSql",
+            "SQLite",
+            "Snowflake"
+          ],
+          "default": "Ansi",
+          "description": "PRQL compiler target dialect to use by default when generating SQL from pipeline definition files."
+        }
+      }
     }
   },
   "scripts": {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -5,7 +5,7 @@ export function compile(prqlString: string): string | ErrorMessage[] {
   const target = <string>workspace.getConfiguration('prql').get('target');
   const options: CompileOptions = { target: target };
   try {
-    // map new compile options to the old prql JS SQL optioins for now
+    // map new compile options to the old prql JS SQL options for now
     const compileOptions = new prql.SQLCompileOptions();
     compileOptions.dialect = targetToDialect(options.target);
     return prql.compile(prqlString, compileOptions) as string;
@@ -51,7 +51,7 @@ export interface SourceLocation {
 
 /**
  * Temp. target to dialect conversion function till we update prql-js.
- * @param target Commpilation target string.
+ * @param target Compilation target string.
  */
 function targetToDialect(target: string | undefined) {
   switch (target) {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1,8 +1,14 @@
-import * as prqlJs from 'prql-js';
+import { workspace } from 'vscode';
+import * as prql from 'prql-js';
 
 export function compile(prqlString: string): string | ErrorMessage[] {
+  const target = <string>workspace.getConfiguration('prql').get('target');
+  const options: CompileOptions = { target: target };
   try {
-    return prqlJs.compile(prqlString) as string;
+    // map new compile options to the old prql JS SQL optioins for now
+    const compileOptions = new prql.SQLCompileOptions();
+    compileOptions.dialect = targetToDialect(options.target);
+    return prql.compile(prqlString, compileOptions) as string;
   } catch (error) {
     if ((error as any)?.message) {
       try {
@@ -14,6 +20,10 @@ export function compile(prqlString: string): string | ErrorMessage[] {
     }
     throw error;
   }
+}
+
+export interface CompileOptions {
+  target?: string;
 }
 
 export interface ErrorMessage {
@@ -37,4 +47,35 @@ export interface ErrorMessage {
 export interface SourceLocation {
   start: [number, number];
   end: [number, number];
+}
+
+/**
+ * Temp. target to dialect conversion function till we update prql-js.
+ * @param target Commpilation target string.
+ */
+function targetToDialect(target: string | undefined) {
+  switch (target) {
+    case 'BigQuery':
+      return prql.Dialect.BigQuery;
+    case 'ClickHouse':
+      return prql.Dialect.ClickHouse;
+    case 'DuckDb':
+      return prql.Dialect.DuckDb;
+    case 'Generic':
+      return prql.Dialect.Generic;
+    case 'Hive':
+      return prql.Dialect.Hive;
+    case 'MsSql':
+      return prql.Dialect.MsSql;
+    case 'MySql':
+      return prql.Dialect.MySql;
+    case 'PostgreSql':
+      return prql.Dialect.PostgreSql;
+    case 'SQLite':
+      return prql.Dialect.SQLite;
+    case 'Snowflake':
+      return prql.Dialect.Snowflake;
+    default:
+      return prql.Dialect.Ansi;
+  }
 }

--- a/src/sql_output/index.ts
+++ b/src/sql_output/index.ts
@@ -73,6 +73,7 @@ async function compilePrql(
   text: string,
   lastOkHtml: string | undefined
 ): Promise<CompilationResult> {
+
   const result = compile(text);
 
   if (Array.isArray(result)) {


### PR DESCRIPTION
Implements prql compile with new `prql.target` setting described in #48.

Some notes on this vscode configuration setting and presentation:

- Defaults to Ansi
- Uses mixed case target system names for better name/target system brand presentation
- Temporarily maps new `CompileOptions` with `target` property to the old `SQLCompileOptions` with `dialect` property for the compile call to work until you release target-related `prql-js` lib update.

This is how `PRQL: Target` setting looks in vscode:

![prql-target-setting-ui](https://user-images.githubusercontent.com/656833/217617056-720390ec-7377-40d0-8d02-cf365bf6bd08.png)
