### PR TITLE
prql-js v0.5.0 update with new prql.CompileOptions target usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.2",
       "dependencies": {
         "@types/vscode": "^1.75.0",
-        "prql-js": "^0.4.2",
+        "prql-js": "^0.5.0",
         "shiki": "^0.14.0"
       },
       "devDependencies": {
@@ -1320,9 +1320,9 @@
       }
     },
     "node_modules/prql-js": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/prql-js/-/prql-js-0.4.2.tgz",
-      "integrity": "sha512-L2EiM9QmOSD0AlZC9WXbN6dO5HeOo8HddKPCBjVo9bCSy67l65B4NqwD9ZfB9korxHXevXqk2F/vTptIDlauNg=="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/prql-js/-/prql-js-0.5.0.tgz",
+      "integrity": "sha512-ozlrhX9uDc350ratvytXeu5T64ChMLVa/k6IG4Okk4gAmnStIZuZWmH8/GH3Vb3TPTo2hgPEdCt3k91rasMl/A=="
     },
     "node_modules/punycode": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
   },
   "dependencies": {
     "@types/vscode": "^1.75.0",
-    "prql-js": "^0.4.2",
+    "prql-js": "^0.5.0",
     "shiki": "^0.14.0"
   },
   "devDependencies": {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -2,12 +2,11 @@ import { workspace } from 'vscode';
 import * as prql from 'prql-js';
 
 export function compile(prqlString: string): string | ErrorMessage[] {
+  // create compile options from prql workspace settings
+  const compileOptions = new prql.CompileOptions();
   const target = <string>workspace.getConfiguration('prql').get('target');
-  const options: CompileOptions = { target: target };
+  compileOptions.target = `sql.${target.toLowerCase()}`;
   try {
-    // map new compile options to the old prql JS SQL options for now
-    const compileOptions = new prql.SQLCompileOptions();
-    compileOptions.dialect = targetToDialect(options.target);
     return prql.compile(prqlString, compileOptions) as string;
   } catch (error) {
     if ((error as any)?.message) {
@@ -20,10 +19,6 @@ export function compile(prqlString: string): string | ErrorMessage[] {
     }
     throw error;
   }
-}
-
-export interface CompileOptions {
-  target?: string;
 }
 
 export interface ErrorMessage {
@@ -47,35 +42,4 @@ export interface ErrorMessage {
 export interface SourceLocation {
   start: [number, number];
   end: [number, number];
-}
-
-/**
- * Temp. target to dialect conversion function till we update prql-js.
- * @param target Compilation target string.
- */
-function targetToDialect(target: string | undefined) {
-  switch (target) {
-    case 'BigQuery':
-      return prql.Dialect.BigQuery;
-    case 'ClickHouse':
-      return prql.Dialect.ClickHouse;
-    case 'DuckDb':
-      return prql.Dialect.DuckDb;
-    case 'Generic':
-      return prql.Dialect.Generic;
-    case 'Hive':
-      return prql.Dialect.Hive;
-    case 'MsSql':
-      return prql.Dialect.MsSql;
-    case 'MySql':
-      return prql.Dialect.MySql;
-    case 'PostgreSql':
-      return prql.Dialect.PostgreSql;
-    case 'SQLite':
-      return prql.Dialect.SQLite;
-    case 'Snowflake':
-      return prql.Dialect.Snowflake;
-    default:
-      return prql.Dialect.Ansi;
-  }
 }


### PR DESCRIPTION
- Bumps `prql-js` to new v0.5.0 (#65)
- Uses new `prql.CompileOptions` with target in extension `compile.ts`
- Completes `prql.target` extension config setting feature implementation (#48)