### PR TITLE
change prql.target extension setting default to Generic and add None option

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,11 +132,12 @@
             "MySql",
             "Postgres",
             "SQLite",
-            "Snowflake"
+            "Snowflake",
+            "None"
           ],
-          "default": "Ansi",
+          "default": "Generic",
           "order": 0,
-          "description": "PRQL compiler target dialect to use by default when generating SQL from pipeline definition files."
+          "description": "PRQL compiler target dialect to use when generating SQL from pipeline definition files."
         },
         "prql.addCompilerSignatureComment": {
           "type": "boolean",

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -13,10 +13,7 @@ export function compile(prqlString: string): string | ErrorMessage[] {
 
   // create compile options from prql workspace settings
   const compileOptions = new prql.CompileOptions();
-  if (target !== 'None') {
-    // set prql target sql dialect
-    compileOptions.target = `sql.${target.toLowerCase()}`;
-  }
+  compileOptions.target = `sql.${target.toLowerCase()}`;
   compileOptions.signature_comment = addCompilerInfo;
 
   try {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1,19 +1,26 @@
-import { workspace } from 'vscode';
+import {
+  workspace,
+  WorkspaceConfiguration
+} from 'vscode';
 import * as prql from 'prql-js';
 import * as constants from './constants';
 
 export function compile(prqlString: string): string | ErrorMessage[] {
+  // get prql settings
+  const prqlSettings: WorkspaceConfiguration = workspace.getConfiguration('prql');
+  const target = <string>prqlSettings.get('target');
+  const addCompilerInfo = <boolean>prqlSettings.get(constants.AddCompilerSignatureComment);
+
   // create compile options from prql workspace settings
   const compileOptions = new prql.CompileOptions();
-  const target = <string>workspace.getConfiguration('prql').get('target');
-  const addCompilerInfo: boolean = <boolean>(
-    workspace
-      .getConfiguration('prql')
-      .get(constants.AddCompilerSignatureComment)
-  );
-  compileOptions.target = `sql.${target.toLowerCase()}`;
+  if (target !== 'None') {
+    // set prql target sql dialect
+    compileOptions.target = `sql.${target.toLowerCase()}`;
+  }
   compileOptions.signature_comment = addCompilerInfo;
+
   try {
+    // run prql compile
     return prql.compile(prqlString, compileOptions) as string;
   } catch (error) {
     if ((error as any)?.message) {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1,15 +1,15 @@
-import {
-  workspace,
-  WorkspaceConfiguration
-} from 'vscode';
+import { workspace, WorkspaceConfiguration } from 'vscode';
 import * as prql from 'prql-js';
 import * as constants from './constants';
 
 export function compile(prqlString: string): string | ErrorMessage[] {
   // get prql settings
-  const prqlSettings: WorkspaceConfiguration = workspace.getConfiguration('prql');
+  const prqlSettings: WorkspaceConfiguration =
+    workspace.getConfiguration('prql');
   const target = <string>prqlSettings.get('target');
-  const addCompilerInfo = <boolean>prqlSettings.get(constants.AddCompilerSignatureComment);
+  const addCompilerInfo = <boolean>(
+    prqlSettings.get(constants.AddCompilerSignatureComment)
+  );
 
   // create compile options from prql workspace settings
   const compileOptions = new prql.CompileOptions();


### PR DESCRIPTION
Resolves #98 after more discussions of our somewhat ambiguous generic and none prql.target options that will be further documented in #97 and should be expanded on in `prql-js` lib docs and examples.