### PR TITLE
linter: remove prettier pre-commit hooks once again

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,15 +1,28 @@
 {
   "root": true,
-  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    "project": ["./tsconfig.json"]
+    "project": [
+      "./tsconfig.json"
+    ]
   },
-  "plugins": ["@typescript-eslint"],
-  "ignorePatterns": ["out", "resources"],
+  "plugins": [
+    "@typescript-eslint"
+  ],
+  "ignorePatterns": [
+    "out",
+    "resources"
+  ],
   "rules": {
     "@typescript-eslint/no-explicit-any": "off",
-    "eol-last": ["error", "always"],
+    "eol-last": [
+      "error",
+      "always"
+    ],
     "@typescript-eslint/quotes": [
       "error",
       "single",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,12 +12,6 @@ repos:
       - id: typos
         # https://github.com/crate-ci/typos/issues/347
         pass_filenames: false
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.4
-    hooks:
-      - id: prettier
-        additional_dependencies:
-          - prettier
 ci:
   # Currently network access isn't supported in the CI product.
   autoupdate_commit_msg: 'chore: pre-commit autoupdate'


### PR DESCRIPTION
to restore changes from PR #62, and reformat updated .eslintrc.json rules once again.

Note: this project uses eslint and should highlight code formatting issues in vscode Problems panel. Make sure to check it and that your updates compile before commit.