### PR TITLE
update prql-js to v0.5.2 for the none prql target option support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.5.1",
       "dependencies": {
         "@types/vscode": "^1.75.1",
-        "prql-js": "^0.5.0",
+        "prql-js": "^0.5.2",
         "shiki": "^0.14.1"
       },
       "devDependencies": {
@@ -1320,9 +1320,9 @@
       }
     },
     "node_modules/prql-js": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/prql-js/-/prql-js-0.5.0.tgz",
-      "integrity": "sha512-ozlrhX9uDc350ratvytXeu5T64ChMLVa/k6IG4Okk4gAmnStIZuZWmH8/GH3Vb3TPTo2hgPEdCt3k91rasMl/A=="
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/prql-js/-/prql-js-0.5.2.tgz",
+      "integrity": "sha512-Akh2Btd+DBo8BT5OWb/4cAOoyu4oHpK31JI3zz1s7/cP+bVZvTjn/FfYcicpwNtvGad3431D0Mc6QRaNHnWzAg=="
     },
     "node_modules/punycode": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
   },
   "dependencies": {
     "@types/vscode": "^1.75.1",
-    "prql-js": "^0.5.0",
+    "prql-js": "^0.5.2",
     "shiki": "^0.14.1"
   },
   "devDependencies": {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -15,8 +15,13 @@ export function compile(prqlString: string): string | ErrorMessage[] {
 
   // create compile options from prql workspace settings
   const compileOptions = new prql.CompileOptions();
-  compileOptions.target = `sql.${target.toLowerCase()}`;
   compileOptions.signature_comment = addCompilerInfo;
+  if (target !== 'None') {
+    compileOptions.target = `sql.${target.toLowerCase()}`;
+  }
+  else {
+    compileOptions.target = 'sql.not_existing';
+  }
 
   try {
     // run prql compile


### PR DESCRIPTION
see #98 for more info.

@max-sixty & @aljazerzen this still doesn't work as expected.

The generated by message in sql preview should have  `target:sql.sqlite` for the prql and settings below.

I did set it to `sql.not_existing` as in this test: https://github.com/PRQL/prql/blob/main/prql-js/tests/test_all.js#L89

See changes in `compile.ts.`

![image](https://user-images.githubusercontent.com/656833/219975653-5b76546e-e314-4586-a4ab-6e5c9a7243dd.png)