### PR TITLE
ci: Automerge dependabot PRs

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -22,3 +22,16 @@ jobs:
           node-version: 16
       - run: npm ci
       - run: npm run compile
+
+  automerge-dependabot:
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+      contents: write
+
+    steps:
+      - uses: fastify/github-action-merge-dependabot@v3
+        with:
+          github-token: ${{ github.token }}
+          use-github-auto-merge: true


### PR DESCRIPTION
This uses automerge; if that doesn't work then revert to the main prql repo approach (and if it does then use this in the main prql repo)
