### PR TITLE
refactor!: Target name changes to reflect upstream changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 See [releases](https://github.com/PRQL/prql-vscode/releases) for a brief summary of added extension features, extension source code zip archive, and `prql-vscode-x.x.x.vsix` extension package download.
 
+## 0.9.0
+
+### Breaking changes
+
+- The `Hive` target option is removed, and the `None` target option is renamed to `Any`.
+
 ## 0.6.0
 
 - Refactor SQL Preview webview implementation

--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ PRQL extension Settings allow you to customize PRQL [compiler options](https://g
 
 ### PRQL Target
 
-PRQL extension and the underlying [`prql-js`](https://github.com/PRQL/prql/tree/main/prql-js#usage) compiler used by this extension supports the following PRQL target dialect options: `Ansi`, `BigQuery`, `ClickHouse`, `DuckDb`, `Generic`, `Hive`, `MsSql`, `MySql`, `Postgres`, `SQLite`, `Snowflake`, and `None`.
+PRQL extension and the underlying [`prql-js`](https://github.com/PRQL/prql/tree/main/prql-js#usage) compiler used by this extension supports the following PRQL target dialect options: `Ansi`, `BigQuery`, `ClickHouse`, `DuckDb`, `Generic`, `MsSql`, `MySql`, `Postgres`, `SQLite`, `Snowflake`, and `Any`.
 
 The `prql.target` extension setting default option value is `Generic`, which will produce SQL that should work with most database management systems. We recommend you set it to the target DB you are working with in your project [workspace settings](https://code.visualstudio.com/docs/getstarted/settings#_creating-user-and-workspace-settings).
 
-You can also disable this PRQL compiler option in vscode extension by setting `prql.target` to `None`. When `prql.target` is set to `None`, PRQL compiler will read the target SQL dialect from `.prql` file header as described in [PRQL Language Book](https://prql-lang.org/book/language-features/target.html). For example, setting `prql.target` to `None` and adding `prql target:sql.postgres` on the first line of your `.prql` query file will produce SQL for `PostgreSQL` database. Otherwise, `Generic` SQL flavor will be used for the generated SQL.
+You can also disable this PRQL compiler option in vscode extension by setting `prql.target` to `Any`. When `prql.target` is set to `Any`, PRQL compiler will read the target SQL dialect from `.prql` file header as described in [PRQL Language Book](https://prql-lang.org/book/language-features/target.html). For example, setting `prql.target` to `Any` and adding `prql target:sql.postgres` on the first line of your `.prql` query file will produce SQL for `PostgreSQL` database. Otherwise, `Generic` SQL flavor will be used for the generated SQL.
 
 ## Developing
 

--- a/package.json
+++ b/package.json
@@ -151,7 +151,6 @@
             "ClickHouse",
             "DuckDb",
             "Generic",
-            "Hive",
             "MsSql",
             "MySql",
             "Postgres",

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
             "Postgres",
             "SQLite",
             "Snowflake",
-            "None"
+            "Any"
           ],
           "default": "Generic",
           "order": 0,

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -144,7 +144,7 @@ async function generateSqlFile(prqlDocumentUri: Uri, prqlCode: string) {
     if (
       addTargetDialectToSqlFilenames &&
       target !== 'Generic' &&
-      target !== 'None'
+      target !== 'Any'
     ) {
       sqlFilenameSuffix = `.${target.toLowerCase()}`;
     }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -15,10 +15,10 @@ export function compile(prqlString: string): string | ErrorMessage[] {
   // create compile options from prql workspace settings
   const compileOptions = new prql.CompileOptions();
   compileOptions.signature_comment = addCompilerInfo;
-  if (target !== 'None') {
+  if (target !== 'Any') {
     compileOptions.target = `sql.${target.toLowerCase()}`;
   } else {
-    compileOptions.target = 'sql.not_existing';
+    compileOptions.target = 'sql.any';
   }
 
   try {


### PR DESCRIPTION
- prql-compiler 0.9.0 will drop the `sql.hive` target.
- Use `Any` instead of `None` for consistency.